### PR TITLE
Fix Implicitly marking parameter $maxItems as nullable is deprecated

### DIFF
--- a/src/ArrayAssertsTrait.php
+++ b/src/ArrayAssertsTrait.php
@@ -158,7 +158,7 @@ trait ArrayAssertsTrait
     public static function assertSequentialArray(
         $array,
         int $minItems,
-        int $maxItems = null,
+        ?int $maxItems = null,
         $constraint = null,
         bool $ignoreKeys = false,
         string $message = ''
@@ -185,7 +185,7 @@ trait ArrayAssertsTrait
      */
     public static function sequentialArray(
         int $minItems,
-        int $maxItems = null,
+        ?int $maxItems = null,
         $constraint = null,
         bool $ignoreKeys = false
     ): SequentialArray {

--- a/src/Constraint/SequentialArray.php
+++ b/src/Constraint/SequentialArray.php
@@ -77,7 +77,7 @@ class SequentialArray extends Constraint
      *
      * @throws InvalidArgumentException
      */
-    public function __construct(int $minItems = 0, int $maxItems = null, $constraint = null, bool $ignoreKeys = false)
+    public function __construct(int $minItems = 0, ?int $maxItems = null, $constraint = null, bool $ignoreKeys = false)
     {
         if ($minItems < 0) {
             throw InvalidArgumentException::create(1, 'non-negative integer');

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -52,7 +52,7 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
     protected function mockConstraint(
         $constraint,
         array $invocationRules = [],
-        array $evaluateParameters = null
+        ?array $evaluateParameters = null
     ) {
         if (!($constraint instanceof Constraint)) {
             return $constraint;

--- a/tests/Unit/ArrayAssertsTraitTest.php
+++ b/tests/Unit/ArrayAssertsTraitTest.php
@@ -450,7 +450,7 @@ class ArrayAssertsTraitTest extends TestCase
     private function mockConstraintInstance(
         string $className,
         array $constructorArguments = [],
-        array $evaluateArguments = null
+        ?array $evaluateArguments = null
     ): MockInterface {
         $instanceMock = Mockery::mock('overload:' . $className, Constraint::class);
 


### PR DESCRIPTION
```
PHP Deprecated:  PhrozenByte\PHPUnitArrayAsserts\ArrayAssertsTrait::assertSequentialArray(): Implicitly marking parameter $maxItems as nullable is deprecated, the explicit nullable type must be used instead in /vendor/phrozenbyte/phpunit-array-asserts/src/ArrayAssertsTrait.php on line 158
PHP Deprecated:  PhrozenByte\PHPUnitArrayAsserts\ArrayAssertsTrait::sequentialArray(): Implicitly marking parameter $maxItems as nullable is deprecated, the explicit nullable type must be used instead in /vendor/phrozenbyte/phpunit-array-asserts/src/ArrayAssertsTrait.php on line 186

```